### PR TITLE
datadog writer: report server alias as tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>org.jmxtrans.jmxtrans</groupId>
 	<artifactId>jmxtrans</artifactId>
-	<version>1.0.2-SNAPSHOT</version>
+	<version>1.0.3-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>jmxtrans</name>
 	<description>JMX metrics exporter</description>

--- a/src/com/googlecode/jmxtrans/model/output/DogStatsDWriter.java
+++ b/src/com/googlecode/jmxtrans/model/output/DogStatsDWriter.java
@@ -23,9 +23,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class DogStatsDWriter extends BaseOutputWriter
 {
@@ -166,7 +164,7 @@ public class DogStatsDWriter extends BaseOutputWriter
     }
 
     private String[] getTagsForWriter(Query query) {
-        List<String> tags = new ArrayList<String>();
+        Set<String> tags = new HashSet<String>();
         String alias = query.getServer().getAlias();
         if (alias != null) {    //server alias is put in service tag
             tags.add("service:" + alias);


### PR DESCRIPTION
/cc @alexism @schleyfox 

Currently, jmxtrans will always put rootPrefix.aliasPrefix before the actual metric name.  If their properties are missing, the default values will be used.  For datadog, we decide to remove both prefixes and add alias prefix to the tags. 
